### PR TITLE
Use of scaling_cur_freq instead of cpuinfo_cur_freq

### DIFF
--- a/daemon/src/main/java/io/minecloud/daemon/StatisticsWatcher.java
+++ b/daemon/src/main/java/io/minecloud/daemon/StatisticsWatcher.java
@@ -52,7 +52,7 @@ public class StatisticsWatcher extends Thread {
                 if (!file.isDirectory())
                     continue;
 
-                File currentFreq = new File(file, "cpufreq/cpuinfo_cur_freq");
+                File currentFreq = new File(file, "cpufreq/scaling_cur_freq");
 
                 if (!currentFreq.exists())
                     continue;


### PR DESCRIPTION
- same data
- ownership root:root 0444 instead of root:root 0400 
  (cpuinfo_cur_freq restricted for a good reason http://comments.gmane.org/gmane.linux.kernel.cpufreq/7005)
